### PR TITLE
`strings.HasPrefix()`の実行例を修正

### DIFF
--- a/articles/54eff8a2039084.md
+++ b/articles/54eff8a2039084.md
@@ -172,7 +172,7 @@ strings.ContainsAny("", "")  // == true
 
 ```go
 strings.HasPrefix("Go言語", "Go")  // == true
-strings.HasPrefix("Go言語", "言語")  // == true
+strings.HasPrefix("Go言語", "言語")  // == false
 ```
 
 


### PR DESCRIPTION
こんにちは。大変役立つ記事をありがとうございます。

一箇所、誤記を発見しました。実際にGo 1.18で確認しましたが、この例はfalseが返ってくるように思います。